### PR TITLE
Add production DB config

### DIFF
--- a/mongoid.yml
+++ b/mongoid.yml
@@ -1,3 +1,9 @@
+production:
+  sessions:
+    default:
+      database: metrics_api_production
+      hosts:
+        - localhost
 development:
   sessions:
     default:


### PR DESCRIPTION
As the metrics API is on a single machine, we can nail this in to localhost for now.
