### PR TITLE
Fix https in metrics links

### DIFF
--- a/features/metrics-api.feature
+++ b/features/metrics-api.feature
@@ -9,9 +9,9 @@ Feature: Metrics API
     When I send a GET request to "metrics"
     Then the response status should be "200"
     And the JSON response should have "$.metrics[0].name" with the text "membership-count"
-    And the JSON response should have "$.metrics[0].url" with the text "http://example.org/metrics/membership-count.json"
+    And the JSON response should have "$.metrics[0].url" with the text "https://example.org/metrics/membership-count.json"
     And the JSON response should have "$.metrics[1].name" with the text "membership-coverage"
-    And the JSON response should have "$.metrics[1].url" with the text "http://example.org/metrics/membership-coverage.json"
+    And the JSON response should have "$.metrics[1].url" with the text "https://example.org/metrics/membership-coverage.json"
     
   Scenario: POSTing data
     Given I authenticate as the user "foo" with the password "bar"

--- a/lib/metrics-api.rb
+++ b/lib/metrics-api.rb
@@ -55,7 +55,7 @@ class MetricsApi < Sinatra::Base
       "metrics" => Metric.all.distinct(:name).sort.map do |name|
         {
           name: name,
-          url: "#{request.scheme}://#{request.host}/metrics/#{name}.json"
+          url: "https://#{request.host}/metrics/#{name}.json"
         }
       end
     }


### PR DESCRIPTION
hardcoded for now. Can't think of a better way, as SSL is handled at the load balancer so the app never sees it.
