### PR TITLE
Fix JSON responses when there's a referer

### DIFF
--- a/features/metrics-api.feature
+++ b/features/metrics-api.feature
@@ -120,3 +120,14 @@ Feature: Metrics API
     And the JSON response should have "$.value.telecoms" with the text "0.33"
     And the JSON response should have "$.value.energy" with the text "0.33"  
     
+Scenario: GETing data with a referer
+  Given there is a metric in the database with the name "membership-coverage"
+  And it has a time of "2013-12-25T15:00:00+00:00"
+  And it has a value of:
+    """
+    {"health":0.34,"telecoms":0.34,"energy":0.34}
+    """
+  And I set headers:
+    | Referer | http://theodi.org |
+  When I send a GET request to "metrics/membership-coverage.json"
+  Then the response status should be "200"

--- a/lib/metrics-api.rb
+++ b/lib/metrics-api.rb
@@ -13,6 +13,9 @@ Mongoid.load!(File.expand_path("../mongoid.yml", File.dirname(__FILE__)), ENV['R
 
 class MetricsApi < Sinatra::Base
   
+  # Disable JSON CSRF protection - this is a JSON API goddammit.
+  set :protection, :except => [:json_csrf]
+
   helpers do
     def protected!
       return if authorized?


### PR DESCRIPTION
Was being filtered by JSON CSRF protection in rack-protection. However, this isn't necessary in this API, so I've removed it.
