### PR TITLE
Small embeds for graphs

### DIFF
--- a/lib/metrics-api/helpers.rb
+++ b/lib/metrics-api/helpers.rb
@@ -205,12 +205,17 @@ module Helpers
     end
   end
 
-  def embed_iframe
-    "<iframe src='#{embed_url}' width='100%' height='100%' frameBorder='0' scrolling='no'></iframe>"
+  def embed_iframe(params = {})
+    "<iframe src='#{embed_url(params)}' width='100%' height='100%' frameBorder='0' scrolling='no'></iframe>"
   end
 
-  def embed_url
-    request.scheme + '://' + request.host_with_port + request.path +  '?' + request.params.merge({layout: "bare"}).to_query
+  def embed_url(params = {})
+    params = request.params.merge(params.merge(
+      {
+        layout: "bare"
+      }
+    )).to_query
+    request.scheme + '://' + request.host_with_port + request.path +  '?' + params
   end
 
 end

--- a/lib/metrics-api/helpers.rb
+++ b/lib/metrics-api/helpers.rb
@@ -42,7 +42,7 @@ module Helpers
     @textcolour = "##{params.fetch('textcolour', '222')}"
     @autorefresh = params.fetch('autorefresh', nil)
 
-    @plotly_modebar = (@layout == 'rich')
+    @plotly_modebar = params.fetch('plotly_modebar', 'false')
   end
 
   def get_start_date params

--- a/lib/public/javascripts/chart.js
+++ b/lib/public/javascripts/chart.js
@@ -1,4 +1,6 @@
 function graph(title, json, textcolour, boxcolour, plotly_modebar) {
+  $('#chart').height($(window).height())
+
   var points = getPoints(json['values'])
 
   if (typeof(points['y'][0]) == 'object') {

--- a/lib/public/javascripts/chart.js
+++ b/lib/public/javascripts/chart.js
@@ -13,7 +13,7 @@ function graph(title, json, textcolour, boxcolour, plotly_modebar) {
     'chart',
     data,
     layout,
-    { displayModeBar: plotly_modebar }
+    { displayModeBar: JSON.parse(plotly_modebar) }
   );
 }
 

--- a/lib/views/metric.erb
+++ b/lib/views/metric.erb
@@ -8,6 +8,6 @@
   </div>
 <% else %>
   <div id="iframe_embed">
-    <%= embed_iframe %>
+    <%= embed_iframe('plotly_modebar' => true) %>
   </div>
 <% end %>

--- a/spec/helpers/helpers_spec.rb
+++ b/spec/helpers/helpers_spec.rb
@@ -296,6 +296,14 @@ describe Helpers do
       expect(helpers.embed_iframe).to eq("<iframe src='#{url}' width='100%' height='100%' frameBorder='0' scrolling='no'></iframe>")
     end
 
+    it 'allows additional params' do
+      expect(helpers.embed_url(parma: 'ham')).to eq(url + "&parma=ham")
+    end
+
+    it 'adds additional params to an embed iframe' do
+      expect(helpers.embed_iframe(parma: 'ham')).to eq("<iframe src='#{url + "&parma=ham"}' width='100%' height='100%' frameBorder='0' scrolling='no'></iframe>")
+    end
+
   end
 
   context 'checks whether to display a single date or a range' do


### PR DESCRIPTION
Fixes #60 

This also removes the `plotly_modebar` for embeds, but makes sure we have it on metric view pages