### PR TITLE
Y axes should start at zero

### DIFF
--- a/lib/public/javascripts/chart.js
+++ b/lib/public/javascripts/chart.js
@@ -78,6 +78,7 @@ function getLayout(title, textcolour, boxcolour) {
       }
     },
     yaxis: {
+      rangemode: 'tozero',
       gridcolor: '#D3D3D3',
       tickangle: 315,
       tickfont: {


### PR DESCRIPTION
Because anything else is bad data presentation. Resolves #122

<!---
@huboard:{"order":0.9998500199975003,"milestone_order":128,"custom_state":""}
-->
