### PR TITLE
Specify date range in dashboard items

### DIFF
--- a/lib/metrics-api.rb
+++ b/lib/metrics-api.rb
@@ -399,7 +399,7 @@ class MetricsApi < Sinatra::Base
       wants.json { data.to_json }
 
       wants.html do
-        value = data[:values].first
+        value = data[:values].first || { value: '' }
         @alternatives = get_alternatives(value[:value])
 
         get_settings(params, value)

--- a/lib/public/javascripts/dashboard.js
+++ b/lib/public/javascripts/dashboard.js
@@ -122,11 +122,12 @@ function showVisualisations(selector, metric) {
   selector.removeClass('hidden')
 }
 
-function populateIframe(iframe, metric) {
+function populateIframe(iframe, metric, daterange) {
+  var daterange = (typeof daterange === 'undefined') ? '/*/*' : '/' + daterange;
   var uri = URI(iframe.attr('src'))
   var qs = uri.search() !== '' ? uri.search() : '?layout=bare'
   var baseURL = iframe.data('base-url')
-  var url = baseURL + metric + qs;
+  var url = baseURL + metric + daterange + qs;
   iframe.attr('src', url)
   iframe.removeClass('hidden')
 }

--- a/lib/public/javascripts/dashboard.js
+++ b/lib/public/javascripts/dashboard.js
@@ -122,6 +122,23 @@ function showVisualisations(selector, metric) {
   selector.removeClass('hidden')
 }
 
+function showDates(selector, type) {
+  selector.find('.date').remove()
+
+  template = $('#date-template').clone()
+  template.removeAttr('id')
+  template.removeClass('hidden')
+
+  template.find('option').each(function(i, option) {
+    $options = $(option)
+    if ($options.data('support').split(',').indexOf(type) == -1) {
+      $options.remove()
+    }
+  })
+
+  selector.find('.date-wrapper').append(template)
+}
+
 function populateIframe(iframe, metric, daterange) {
   var daterange = (typeof daterange === 'undefined') ? '/*/*' : '/' + daterange;
   var uri = URI(iframe.attr('src'))

--- a/lib/public/javascripts/dashboard.js
+++ b/lib/public/javascripts/dashboard.js
@@ -127,6 +127,7 @@ function showDates(selector, type) {
 
   var template = $('#date-template').clone()
   var index = selector.find('.index').val()
+  var wrapper = selector.find('.date-wrapper')
 
   template.removeAttr('id')
   template.removeClass('hidden')
@@ -139,7 +140,8 @@ function showDates(selector, type) {
     }
   })
 
-  selector.find('.date-wrapper').append(template)
+  wrapper.append(template)
+  wrapper.removeClass('hidden')
 }
 
 function populateIframe(iframe, metric, daterange) {

--- a/lib/public/javascripts/dashboard.js
+++ b/lib/public/javascripts/dashboard.js
@@ -354,5 +354,7 @@ function setInputs(table) {
     $(col).find('.col').attr('name', 'dashboard[metrics]['+ i +'][col]')
     $(col).find('.height').attr('name', 'dashboard[metrics]['+ i +'][height]')
     $(col).find('.width').attr('name', 'dashboard[metrics]['+ i +'][width]')
+    $(col).find('.date').attr('name', 'dashboard[metrics]['+ i +'][date]')
+    $(col).find('.index').val(i)
   })
 }

--- a/lib/public/javascripts/dashboard.js
+++ b/lib/public/javascripts/dashboard.js
@@ -125,9 +125,12 @@ function showVisualisations(selector, metric) {
 function showDates(selector, type) {
   selector.find('.date').remove()
 
-  template = $('#date-template').clone()
+  var template = $('#date-template').clone()
+  var index = selector.find('.index').val()
+
   template.removeAttr('id')
   template.removeClass('hidden')
+  template.attr('name', 'dashboard[metrics]['+ index +'][date]')
 
   template.find('option').each(function(i, option) {
     $options = $(option)

--- a/lib/views/dashboards/new.erb
+++ b/lib/views/dashboards/new.erb
@@ -215,5 +215,16 @@
       td.find('.width').val(span)
     })
 
+    $(document).on('change', '.date', function() {
+      $this = $(this)
+
+      var date = $this.val()
+      var td = $this.closest('td')
+      var metric = td.find('.metric').val()
+      var iframe = td.find('iframe')
+
+      populateIframe(iframe, metric, date)
+    })
+
   });
 </script>

--- a/lib/views/dashboards/new.erb
+++ b/lib/views/dashboards/new.erb
@@ -42,6 +42,18 @@
 
   <div class="form-group">
     <table id="dashboard" class="hidden table"></table>
+
+    <select name='date' id='date-template' class='form-control date input-sm hidden'>
+      <option value="*/*" data-support="pie,chart,number,target">Default</option>
+      <option value="latest" data-support="pie,number,target">Latest metric</option>
+      <option value="since-beginning-of-month" data-support="chart">Current month</option>
+      <option value="since-beginning-of-week" data-support="chart">Current week</option>
+      <option value="since-beginning-of-year" data-support="chart">Current year</option>
+      <option value="since-midnight" data-support="pie,number,target">Current day</option>
+      <option value="P30D/*" data-support="chart">Last 30 days</option>
+      <option value="P7D/*" data-support="chart">Last 7 days</option>
+    </select>
+
     <div id="metric-template" class="hidden">
       <iframe src='' width='100%' height='300px' frameBorder='0' scrolling='no' data-base-url='<%= request.scheme + '://' + request.host_with_port +  '/metrics/' %>' class='hidden'></iframe>
 
@@ -116,16 +128,7 @@
 
       <div class='form-group form-group-sm col-md-12'>
         <label for='date' class='text-right'>Date Range</label>
-        <select name='date' id='date' class='form-control date input-sm'>
-          <option value="*/*">Default</option>
-          <option value="latest">Latest metric</option>
-          <option value="since-beginning-of-month">Current month</option>
-          <option value="since-beginning-of-week">Current week</option>
-          <option value="since-beginning-of-year">Current year</option>
-          <option value="since-midnight">Current day</option>
-          <option value="P30D/*">Last 30 days</option>
-          <option value="P7D/*">Last 7 days</option>
-        </select>
+        <div class='date-wrapper'></div>
       </div>
 
       <input type="hidden" class="row" />
@@ -181,14 +184,19 @@
 
       showVisualisations(visualisations, selected)
       td.find('[value='+ defaultVis +']').prop('checked', true)
+      showDates(td, defaultVis)
     })
 
     $(document).on('change', '.visualisation', function() {
-      var iframe = $(this).parents().eq(3).find('iframe')
+      $this = $(this)
+
+      var td = $this.closest("td")
+      var iframe = td.find('iframe')
       var params = {
         type: $(this).val()
       }
 
+      showDates(td, $(this).val())
       setSrc(iframe, params);
     })
 

--- a/lib/views/dashboards/new.erb
+++ b/lib/views/dashboards/new.erb
@@ -51,7 +51,8 @@
           <select class="form-control metric input-sm">
             <option>-- Select a metric--</options>
             <% @metrics.each do |metric| %>
-              <option data-visualisations="<%= get_alternatives(metric.value).join(',') %>"><%= metric.name %></option>
+              <% get_settings({'metric' => metric.name}, metric) %>
+              <option data-visualisations="<%= get_alternatives(metric.value).join(',') %>" data-default="<%= @type %>"><%= metric.name %></option>
             <% end %>
           </select>
         </div>
@@ -168,9 +169,18 @@
     })
 
     $(document).on('change', '.metric', function() {
-      var iframe = $(this).parents().eq(2).find('iframe')
-      populateIframe(iframe, $(this).val())
-      showVisualisations($(this).parents().eq(2).find('.visualisations'), $(this).find(":selected"))
+      $this = $(this)
+
+      var td = $this.closest("td")
+      var iframe = td.find('iframe')
+      var visualisations = td.find('.visualisations')
+      var selected = $this.find(":selected")
+      var defaultVis = selected.data('default')
+
+      populateIframe(iframe, $this.val())
+
+      showVisualisations(visualisations, selected)
+      td.find('[value='+ defaultVis +']').prop('checked', true)
     })
 
     $(document).on('change', '.visualisation', function() {

--- a/lib/views/dashboards/new.erb
+++ b/lib/views/dashboards/new.erb
@@ -113,6 +113,20 @@
         </div>
       </div>
 
+      <div class='form-group form-group-sm col-md-12'>
+        <label for='date' class='text-right'>Date Range</label>
+        <select name='date' id='date' class='form-control date input-sm'>
+          <option value="*/*">Default</option>
+          <option value="latest">Latest metric</option>
+          <option value="since-beginning-of-month">Current month</option>
+          <option value="since-beginning-of-week">Current week</option>
+          <option value="since-beginning-of-year">Current year</option>
+          <option value="since-midnight">Current day</option>
+          <option value="P30D/*">Last 30 days</option>
+          <option value="P7D/*">Last 7 days</option>
+        </select>
+      </div>
+
       <input type="hidden" class="row" />
       <input type="hidden" class="col" />
       <input type="hidden" class="width" />

--- a/lib/views/dashboards/new.erb
+++ b/lib/views/dashboards/new.erb
@@ -135,6 +135,7 @@
       <input type="hidden" class="col" />
       <input type="hidden" class="width" />
       <input type="hidden" class="height" />
+      <input type="hidden" class="index" />
 
     </div>
   </div>

--- a/lib/views/dashboards/new.erb
+++ b/lib/views/dashboards/new.erb
@@ -126,9 +126,8 @@
         </div>
       </div>
 
-      <div class='form-group form-group-sm col-md-12'>
+      <div class='form-group form-group-sm col-md-12 date-wrapper hidden'>
         <label for='date' class='text-right'>Date Range</label>
-        <div class='date-wrapper'></div>
       </div>
 
       <input type="hidden" class="row" />

--- a/lib/views/dashboards/new.erb
+++ b/lib/views/dashboards/new.erb
@@ -99,15 +99,15 @@
         </div>
       </div>
 
-      <div class='form-group form-group-sm col-md-12'>
         <label for='columns' class='text-right'>Number of columns</label>
+      <div class='form-group form-group-sm col-md-6'>
         <div class='input-group col-md-12'>
           <select name='width' id='width' class='form-control width-selector input-sm'></select>
         </div>
       </div>
 
-      <div class='form-group form-group-sm col-md-12'>
         <label for='rows' class='text-right'>Number of rows</label>
+      <div class='form-group form-group-sm col-md-6'>
         <div class='input-group col-md-12'>
           <select name='height' id='height' class='form-control height-selector input-sm'></select>
         </div>

--- a/lib/views/dashboards/new.erb
+++ b/lib/views/dashboards/new.erb
@@ -99,15 +99,15 @@
         </div>
       </div>
 
-        <label for='columns' class='text-right'>Number of columns</label>
       <div class='form-group form-group-sm col-md-6'>
+        <label for='columns' class='text-right'>Width</label>
         <div class='input-group col-md-12'>
           <select name='width' id='width' class='form-control width-selector input-sm'></select>
         </div>
       </div>
 
-        <label for='rows' class='text-right'>Number of rows</label>
       <div class='form-group form-group-sm col-md-6'>
+        <label for='rows' class='text-right'>Height</label>
         <div class='input-group col-md-12'>
           <select name='height' id='height' class='form-control height-selector input-sm'></select>
         </div>

--- a/lib/views/dashboards/show.erb
+++ b/lib/views/dashboards/show.erb
@@ -2,7 +2,7 @@
   <% @dashboard.metrics.each do |metric| %>
     <li class="row-<%= metric[:row] %> col-<%= metric[:col] %> height-<%= metric[:height] || 1 %> width-<%= metric[:width] || 1 %>">
       <div style="postition: relative">
-        <iframe src='/metrics/<%= metric[:name] %>?layout=bare&boxcolour=<%= metric[:boxcolour] %>&textcolour=<%= metric[:textcolour] %><%= metric[:visualisation].blank? ? '' : "&type=#{metric[:visualisation]}" %>'
+        <iframe src='/metrics/<%= metric[:name] %>/<%= metric[:date] || '*/*' %>?layout=bare&boxcolour=<%= metric[:boxcolour] %>&textcolour=<%= metric[:textcolour] %><%= metric[:visualisation].blank? ? '' : "&type=#{metric[:visualisation]}" %>'
                 width='100%'
                 height='100%'
                 frameBorder='0'

--- a/lib/views/pie.erb
+++ b/lib/views/pie.erb
@@ -45,9 +45,11 @@ $.getJSON(document.URL + '?with_path=true', function(json) {
 function pie(json) {
   $('#chart').height($(window).height())
 
+  value = typeof(json.value) === 'undefined' ? json.values[0] : json.value
+
   var data = [{
-    values: extractValues(json.value, '//total'),
-    labels: extractKeys(json.value, '//total'),
+    values: extractValues(value, '//total'),
+    labels: extractKeys(value, '//total'),
     type: 'pie',
     textinfo: 'label+percent',
     marker: {

--- a/spec/javascripts/dashboard_spec.js
+++ b/spec/javascripts/dashboard_spec.js
@@ -1,9 +1,11 @@
 describe('dashboard.js', function() {
-  beforeEach(function() {
-    fixture = loadFixtures("dashboard.html")
-  })
 
   describe('growRow', function() {
+
+    beforeEach(function() {
+      fixture = loadFixtures("dashboard.html")
+    })
+
     it ('applies the rowspan correctly', function() {
       col = $('table td#a0')
 
@@ -116,6 +118,10 @@ describe('dashboard.js', function() {
 
   describe('growCol', function() {
 
+    beforeEach(function() {
+      fixture = loadFixtures("dashboard.html")
+    })
+
     it ('applies a colspan', function() {
       col = $('table td#a0')
 
@@ -194,6 +200,31 @@ describe('dashboard.js', function() {
 
       expect($('table td#a1').attr('colspan')).toEqual('2')
       expect($('#row-a #a2').length).toEqual(0)
+    })
+
+  })
+
+  describe('populateIframe', function() {
+
+    beforeEach(function() {
+      loadFixtures("iframe.html")
+      iframe = $('iframe')
+    })
+
+    it ('populates an iframe with a metric', function() {
+      populateIframe(iframe, 'my-awesome-metric')
+      expect(iframe.attr('src')).toEqual('http://example.org/metrics/my-awesome-metric/*/*?layout=bare')
+    })
+
+    it ('populates an iframe with a custom daterange', function() {
+      populateIframe(iframe, 'my-awesome-metric', 'my-custom-date-range')
+      expect(iframe.attr('src')).toEqual('http://example.org/metrics/my-awesome-metric/my-custom-date-range?layout=bare')
+    })
+
+    it ('retains query strings', function() {
+      iframe.attr('src', 'http://example.org/metrics/my-awesome-metric/*/*?layout=bare&foo=bar')
+      populateIframe(iframe, 'my-other-awesome-metric')
+      expect(iframe.attr('src')).toEqual('http://example.org/metrics/my-other-awesome-metric/*/*?layout=bare&foo=bar')
     })
 
   })

--- a/spec/javascripts/dashboard_spec.js
+++ b/spec/javascripts/dashboard_spec.js
@@ -290,6 +290,12 @@ describe('dashboard.js', function() {
       expect(select.attr('name')).toEqual('dashboard[metrics][99][date]')
     })
 
+    it('unhides the wrapper', function() {
+      showDates($('.form'), 'target')
+
+      expect($('.date-wrapper')).not.toHaveClass('hidden')
+    })
+
 
   })
 

--- a/spec/javascripts/dashboard_spec.js
+++ b/spec/javascripts/dashboard_spec.js
@@ -282,6 +282,15 @@ describe('dashboard.js', function() {
       expect($(options[2]).val()).toEqual('since-midnight')
     })
 
+    it('sets the index correctly', function() {
+      showDates($('.form'), 'target')
+
+      select = $('.date-wrapper select')
+
+      expect(select.attr('name')).toEqual('dashboard[metrics][99][date]')
+    })
+
+
   })
 
 })

--- a/spec/javascripts/dashboard_spec.js
+++ b/spec/javascripts/dashboard_spec.js
@@ -229,4 +229,59 @@ describe('dashboard.js', function() {
 
   })
 
+  describe('showDates', function() {
+
+    beforeEach(function() {
+      loadFixtures("dates.html")
+    })
+
+    it('shows supported date types for a pie chart', function() {
+      showDates($('.form'), 'pie')
+
+      options = $('.date-wrapper select option')
+
+      expect(options.length).toEqual(3)
+      expect($(options[0]).val()).toEqual('*/*')
+      expect($(options[1]).val()).toEqual('latest')
+      expect($(options[2]).val()).toEqual('since-midnight')
+    })
+
+    it('shows supported date types for a chart', function() {
+      showDates($('.form'), 'chart')
+
+      options = $('.date-wrapper select option')
+
+      expect(options.length).toEqual(6)
+      expect($(options[0]).val()).toEqual('*/*')
+      expect($(options[1]).val()).toEqual('since-beginning-of-month')
+      expect($(options[2]).val()).toEqual('since-beginning-of-week')
+      expect($(options[3]).val()).toEqual('since-beginning-of-year')
+      expect($(options[4]).val()).toEqual('P30D/*')
+      expect($(options[5]).val()).toEqual('P7D/*')
+    })
+
+    it('shows supported date types for a number', function() {
+      showDates($('.form'), 'number')
+
+      options = $('.date-wrapper select option')
+
+      expect(options.length).toEqual(3)
+      expect($(options[0]).val()).toEqual('*/*')
+      expect($(options[1]).val()).toEqual('latest')
+      expect($(options[2]).val()).toEqual('since-midnight')
+    })
+
+    it('shows supported date types for a target', function() {
+      showDates($('.form'), 'target')
+
+      options = $('.date-wrapper select option')
+
+      expect(options.length).toEqual(3)
+      expect($(options[0]).val()).toEqual('*/*')
+      expect($(options[1]).val()).toEqual('latest')
+      expect($(options[2]).val()).toEqual('since-midnight')
+    })
+
+  })
+
 })

--- a/spec/javascripts/fixtures/dates.html
+++ b/spec/javascripts/fixtures/dates.html
@@ -11,5 +11,6 @@
 
 
 <div class="form">
+  <input class="index" value="99" />
   <div class="date-wrapper"></div>
 </div>

--- a/spec/javascripts/fixtures/dates.html
+++ b/spec/javascripts/fixtures/dates.html
@@ -12,5 +12,5 @@
 
 <div class="form">
   <input class="index" value="99" />
-  <div class="date-wrapper"></div>
+  <div class="date-wrapper hidden"></div>
 </div>

--- a/spec/javascripts/fixtures/dates.html
+++ b/spec/javascripts/fixtures/dates.html
@@ -1,0 +1,15 @@
+<select name='date' id='date-template' class='form-control date input-sm hidden'>
+  <option value="*/*" data-support="pie,chart,number,target">Default</option>
+  <option value="latest" data-support="pie,number,target">Latest metric</option>
+  <option value="since-beginning-of-month" data-support="chart">Current month</option>
+  <option value="since-beginning-of-week" data-support="chart">Current week</option>
+  <option value="since-beginning-of-year" data-support="chart">Current year</option>
+  <option value="since-midnight" data-support="pie,number,target">Current day</option>
+  <option value="P30D/*" data-support="chart">Last 30 days</option>
+  <option value="P7D/*" data-support="chart">Last 7 days</option>
+</select>
+
+
+<div class="form">
+  <div class="date-wrapper"></div>
+</div>

--- a/spec/javascripts/fixtures/iframe.html
+++ b/spec/javascripts/fixtures/iframe.html
@@ -1,0 +1,1 @@
+<iframe src='' width='100%' height='300px' frameBorder='0' scrolling='no' data-base-url='http://example.org/metrics/' class='hidden'></iframe>


### PR DESCRIPTION
This contains a few fixes where certain date ranges broke things. I've also made it so you can only select a date range when it makes sense for a particular visualisation (e.g. it makes no sense for numbers to have date ranges)