### PR TITLE
Fallback for chart failure

### DIFF
--- a/lib/views/chart.erb
+++ b/lib/views/chart.erb
@@ -44,7 +44,11 @@
 <script>
 function loadMetric() {
   $.getJSON(document.URL, function(json) {
-    graph('<%= @title["en"] %>', json, '<%= @textcolour %>', '<%= @boxcolour %>', '<%= @plotly_modebar %>', '<%= @datatype %>', '<%= @date_format %>')
+      if (json.count === 0) {
+          $("#last-updated").append("No data detected for selected range, please customise date range via the Dates tab below")
+      } else {
+          graph('<%= @title["en"] %>', json, '<%= @textcolour %>', '<%= @boxcolour %>', '<%= @plotly_modebar %>', '<%= @datatype %>', '<%= @date_format %>')
+      }
   })
 }
 


### PR DESCRIPTION
This will trigger any time a JSON object with count value 0 has been returned by API.
This is a very small patch but should cover edge cases where data for an endpoint has no values within the last 30 days. I reasoned this was the best solution to this because anything else would involve changing the logic of several methods in `metrics_helpers.rb` 
```ruby
datetime_path()
get_single_metric()
get_metric_range()
```

the latter two of these are likely to be refactored with the work entailed in #173. At present the date tab retrieves the earliest possible date for a metrics endpoint, so I think directing users to that tab and including some text where the plotly chart would usually render is a sufficient workaround. 
