### PR TITLE
Include missing 'a' in visualisation types tab

### DIFF
--- a/lib/views/includes/configuration-form.erb
+++ b/lib/views/includes/configuration-form.erb
@@ -5,7 +5,7 @@
     <ul class="nav nav-tabs" role="tablist">
       <li role="presentation" class="active">
         <a href="#types" id="type-tab" role="tab" data-toggle="tab" aria-controls="types" aria-expanded="true">
-          Visulisation types
+          Visualisation types
         </a>
       </li>
       <li role="presentation" >


### PR DESCRIPTION
This PR fixes #274

Changes proposed in this pull request:

- spelling correction

